### PR TITLE
Fix bird codes parsing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,1 +1,4 @@
 language: go
+
+script:
+  - go test -v ./...

--- a/bird_socket.go
+++ b/bird_socket.go
@@ -1,6 +1,7 @@
 package birdsocket
 
 import (
+	"bytes"
 	"net"
 	"regexp"
 	"strings"
@@ -9,7 +10,13 @@ import (
 var birdReturnCodeRegex *regexp.Regexp
 
 func init() {
-	birdReturnCodeRegex = regexp.MustCompile("\\d{4} \n$")
+	// Requests are commands encoded as a single line of text,
+	// replies are sequences of lines starting with a four-digit code
+	// followed by either a space (if it's the last line of the reply)
+	// or a minus sign (when the reply is going to continue with the next line),
+	// the rest of the line contains a textual message semantics of which depends
+	// on the numeric code.
+	birdReturnCodeRegex = regexp.MustCompile(`(?m)^(\d{4})(?:\s|-)`)
 }
 
 // BirdSocket encapsulates communication with Bird routing daemon
@@ -103,16 +110,20 @@ func (s *BirdSocket) readFromSocket(conn net.Conn) ([]byte, error) {
 		}
 
 		b = append(b, buf[:n]...)
-		done = endsWithBirdReturnCode(b)
+		done = isBirdCommandCompleted(b)
 	}
 
 	return b, nil
 }
 
-func endsWithBirdReturnCode(b []byte) bool {
-	if len(b) < 6 {
-		return false
+func isBirdCommandCompleted(b []byte) bool {
+	codes := birdReturnCodeRegex.FindAll(b, -1)
+	for _, c := range codes {
+		// Reply codes starting with 0 stand for
+		// `action successfully completed' messages
+		if bytes.HasPrefix(c, []byte("0")) {
+			return true
+		}
 	}
-
-	return birdReturnCodeRegex.Match(b[len(b)-6:])
+	return false
 }

--- a/bird_socket.go
+++ b/bird_socket.go
@@ -16,7 +16,7 @@ func init() {
 	// or a minus sign (when the reply is going to continue with the next line),
 	// the rest of the line contains a textual message semantics of which depends
 	// on the numeric code.
-	birdReturnCodeRegex = regexp.MustCompile(`(?m)^(\d{4})(?:\s|-)`)
+	birdReturnCodeRegex = regexp.MustCompile(`(?m)^(\d{4})`)
 }
 
 // BirdSocket encapsulates communication with Bird routing daemon
@@ -110,13 +110,13 @@ func (s *BirdSocket) readFromSocket(conn net.Conn) ([]byte, error) {
 		}
 
 		b = append(b, buf[:n]...)
-		done = isBirdCommandCompleted(b)
+		done = containsActionCompletedCode(b)
 	}
 
 	return b, nil
 }
 
-func isBirdCommandCompleted(b []byte) bool {
+func containsActionCompletedCode(b []byte) bool {
 	codes := birdReturnCodeRegex.FindAll(b, -1)
 	for _, c := range codes {
 		// Reply codes starting with 0 stand for

--- a/bird_socket_test.go
+++ b/bird_socket_test.go
@@ -6,58 +6,105 @@ import (
 	"github.com/czerwonk/testutils/assert"
 )
 
+// TestBirdSocketConnection simulate a scenario in
+// which the BirdSocket read buffer contains the
+// string sent in output by Bird whenever a new
+// connection is initiated
 func TestBirdSocketConnection(t *testing.T) {
 	out := "0001 BIRD 1.6.4 ready.\n"
-	completed := isBirdCommandCompleted([]byte(out))
+	completed := containsActionCompletedCode([]byte(out))
 
-	assert.True("Connect completed", completed, t)
+	assert.True("'connect' successfully completed", completed, t)
 }
 
+// TestBirdShowProtocols simulate a scenario in which
+// the full output of the 'show protocols' command is
+// saved in the BirdSocket read buffer
 func TestBirdShowProtocols(t *testing.T) {
-	out := "show protocols\n" +
-		"2002-name     proto    table    state  since       info\n" +
+	out := "2002-name     proto    table    state  since       info\n" +
 		"1002-device1  Device   master   up     2018-12-21 12:35:11\n" +
 		" direct1  Direct   master   up     2018-12-21 12:35:11\n" +
 		" kernel1  Kernel   master   up     2018-12-21 12:35:11\n" +
 		" SAR2     BGP      master   down   2018-12-21 12:35:11  Error: Invalid next hop\n" +
 		" SAR1     BGP      master   down   2018-12-21 12:35:11  Error: Invalid next hop\n" +
 		"0000\n"
-	completed := isBirdCommandCompleted([]byte(out))
+	completed := containsActionCompletedCode([]byte(out))
 
-	assert.True("'show protocols' completed", completed, t)
+	assert.True("'show protocols' successfully completed", completed, t)
 }
 
+// TestIncompleteBirdShowProtocols simulate a scenario in which
+// the 'action successfully completed' Bird response code
+// is not present in the output of the 'show protocols' command
+// saved in the BirdSocket read buffer
 func TestIncompleteBirdShowProtocols(t *testing.T) {
-	out := "show protocols\n" +
-		"2002-name     proto    table    state  since       info\n" +
-		"1002-device1  Device   master   up     2018-12-21 12:35:11\n" +
+	out := "1002-device1  Device   master   up     2018-12-21 12:35:11\n" +
 		" direct1  Direct   master   up     2018-12-21 12:35:11\n" +
 		" kernel1  Kernel   master   up     2018-12-21 12:35:11\n"
-	completed := isBirdCommandCompleted([]byte(out))
+	completed := containsActionCompletedCode([]byte(out))
 
-	assert.False("'show protocols' completed", completed, t)
+	assert.False("'show protocols' successfully completed", completed, t)
 }
 
+// TestTruncatedBirdShowProtocols simulate a scenario in which
+// the 'action successfully completed' Bird response code
+// is present in the output of the 'show protocols' command
+// saved in the BirdSocket read buffer,
+// however the response of the Bird deamon is not yet completed
+// (the final new line is not present in the buffer)
+func TestTruncatedBirdShowProtocols(t *testing.T) {
+	out := "1002-device1  Device   master   up     2018-12-21 12:35:11\n" +
+		" direct1  Direct   master   up     2018-12-21 12:35:11\n" +
+		" kernel1  Kernel   master   up     2018-12-21 12:35:11\n" +
+		" SAR2     BGP      master   down   2018-12-21 12:35:11  Error: Invalid next hop\n" +
+		" SAR1     BGP      master   down   2018-12-21 12:35:11  Error: Invalid next hop\n" +
+		"0000"
+	completed := containsActionCompletedCode([]byte(out))
+
+	assert.True("'show protocols' successfully completed", completed, t)
+}
+
+// TestBirdShowStatus simulate a scenario in which
+// the full output of the 'show status' command is
+// saved in the BirdSocket read buffer
 func TestBirdShowStatus(t *testing.T) {
-	out := "show status\n" +
-		"1000-BIRD 1.6.4\n" +
+	out := "1000-BIRD 1.6.4\n" +
 		"1011-Router ID is 192.168.1.9\n" +
 		" Current server time is 2018-12-27 12:15:01\n" +
 		" Last reboot on 2018-12-21 12:35:11\n" +
 		" Last reconfiguration on 2018-12-21 12:35:11\n" +
 		"0013 Daemon is up and running\n"
-	completed := isBirdCommandCompleted([]byte(out))
+	completed := containsActionCompletedCode([]byte(out))
 
-	assert.True("'show protocols' completed", completed, t)
+	assert.True("'show status' successfully completed", completed, t)
 }
 
+// TestIncompleteBirdShowStatus simulate a scenario in which
+// the 'action successfully completed' Bird response code
+// is not present in the output of the 'show status' command
+// saved in the BirdSocket read buffer
 func TestIncompleteBirdShowStatus(t *testing.T) {
-	out := "show status\n" +
-		"1000-BIRD 1.6.4\n" +
-		"1011-Router ID is 192.168.1.9\n" +
+	out := "1011-Router ID is 192.168.1.9\n" +
 		" Current server time is 2018-12-27 12:15:01\n" +
 		" Last reboot on 2018-12-21 12:35:11\n"
-	completed := isBirdCommandCompleted([]byte(out))
+	completed := containsActionCompletedCode([]byte(out))
 
-	assert.False("'show protocols' completed", completed, t)
+	assert.False("'show status' successfully completed", completed, t)
+}
+
+// TestTruncatedBirdShowStatus simulate a scenario in which
+// the 'action successfully completed' Bird response code
+// is present in the output of the 'show status' command
+// saved in the BirdSocket read buffer,
+// however the response of the Bird deamon is not yet completed
+// (the final new line is not present in the buffer)
+func TestTruncatedBirdShowStatus(t *testing.T) {
+	out := "1011-Router ID is 192.168.1.9\n" +
+		" Current server time is 2018-12-27 12:15:01\n" +
+		" Last reboot on 2018-12-21 12:35:11\n" +
+		" Last reconfiguration on 2018-12-21 12:35:11\n" +
+		"0013 Daemon is up and running"
+	completed := containsActionCompletedCode([]byte(out))
+
+	assert.True("'show status' successfully completed", completed, t)
 }

--- a/bird_socket_test.go
+++ b/bird_socket_test.go
@@ -1,0 +1,41 @@
+package birdsocket
+
+import (
+	"testing"
+
+	"github.com/czerwonk/testutils/assert"
+)
+
+func TestBirdSocketConnection(t *testing.T) {
+	out := "0001 BIRD 1.6.4 ready.\n"
+	completed := isBirdCommandCompleted([]byte(out))
+
+	assert.True("Connect completed", completed, t)
+}
+
+func TestBirdShowProtocols(t *testing.T) {
+	out := "show protocols\n" +
+		"2002-name     proto    table    state  since       info\n" +
+		"1002-device1  Device   master   up     2018-12-21 12:35:11\n" +
+		" direct1  Direct   master   up     2018-12-21 12:35:11\n" +
+		" kernel1  Kernel   master   up     2018-12-21 12:35:11\n" +
+		" SAR2     BGP      master   down   2018-12-21 12:35:11  Error: Invalid next hop\n" +
+		" SAR1     BGP      master   down   2018-12-21 12:35:11  Error: Invalid next hop\n" +
+		"0000\n"
+	completed := isBirdCommandCompleted([]byte(out))
+
+	assert.True("'show protocols' completed", completed, t)
+}
+
+func TestBirdShowStatus(t *testing.T) {
+	out := "show status\n" +
+		"1000-BIRD 1.6.4\n" +
+		"1011-Router ID is 192.168.1.9\n" +
+		" Current server time is 2018-12-27 12:15:01\n" +
+		" Last reboot on 2018-12-21 12:35:11\n" +
+		" Last reconfiguration on 2018-12-21 12:35:11\n" +
+		"0013 Daemon is up and running\n"
+	completed := isBirdCommandCompleted([]byte(out))
+
+	assert.True("'show protocols' completed", completed, t)
+}

--- a/bird_socket_test.go
+++ b/bird_socket_test.go
@@ -27,6 +27,17 @@ func TestBirdShowProtocols(t *testing.T) {
 	assert.True("'show protocols' completed", completed, t)
 }
 
+func TestIncompleteBirdShowProtocols(t *testing.T) {
+	out := "show protocols\n" +
+		"2002-name     proto    table    state  since       info\n" +
+		"1002-device1  Device   master   up     2018-12-21 12:35:11\n" +
+		" direct1  Direct   master   up     2018-12-21 12:35:11\n" +
+		" kernel1  Kernel   master   up     2018-12-21 12:35:11\n"
+	completed := isBirdCommandCompleted([]byte(out))
+
+	assert.False("'show protocols' completed", completed, t)
+}
+
 func TestBirdShowStatus(t *testing.T) {
 	out := "show status\n" +
 		"1000-BIRD 1.6.4\n" +
@@ -38,4 +49,15 @@ func TestBirdShowStatus(t *testing.T) {
 	completed := isBirdCommandCompleted([]byte(out))
 
 	assert.True("'show protocols' completed", completed, t)
+}
+
+func TestIncompleteBirdShowStatus(t *testing.T) {
+	out := "show status\n" +
+		"1000-BIRD 1.6.4\n" +
+		"1011-Router ID is 192.168.1.9\n" +
+		" Current server time is 2018-12-27 12:15:01\n" +
+		" Last reboot on 2018-12-21 12:35:11\n"
+	completed := isBirdCommandCompleted([]byte(out))
+
+	assert.False("'show protocols' completed", completed, t)
 }


### PR DESCRIPTION
The current implementation of the Bird return code handling logic is unable to handle correctly the output of the `show status` command.

The Bird documentation published at https://bird.network.cz/?get_doc&v=16&f=prog-2.html#ss2.9 describe the protocol used by Bird to output the commands results as follows:

```
Requests are commands encoded as a single line of text, replies are sequences of lines starting
with a four-digit code followed by either a space (if it's the last line of the reply) or a minus sign
(when the reply is going to continue with the next line), the rest of the line contains a textual
message semantics of which depends on the numeric code. If a reply line has the same code as the
previous one and it's a continuation line, the whole prefix can be replaced by a single white space
character.

Reply codes starting with 0 stand for `action successfully completed' messages, 1 means `table
entry', 8 `runtime error' and 9 `syntax error'. 
```

This PR replace the currently used `birdReturnCodeRegex` with a new multiline regular expression matching Bird return codes as described by the documentation.

In addition, some tests cases are added to test the implementation agains the `show protocols` and `show status` commands.